### PR TITLE
Enn

### DIFF
--- a/test/nn/conv/test_equivariant_conv.py
+++ b/test/nn/conv/test_equivariant_conv.py
@@ -17,13 +17,24 @@ def test_equivariant_conv():
     local_nn = Linear(2 * 16 + 1, 32)
     global_nn = Linear(16 + 32, 16)
 
-    conv = EquivariantConv(local_nn, pos_nn, vel_nn, global_nn)
+    conv = EquivariantConv(local_nn, pos_nn, vel_nn, global_nn, use_fc=True)
     assert conv.__repr__() == (
         'EquivariantConv('
         'local_nn=Linear(in_features=33, out_features=32, bias=True),'
         ' pos_nn=Linear(in_features=32, out_features=1, bias=True),'
         ' vel_nn=Linear(in_features=16, out_features=1, bias=True),'
         ' global_nn=Linear(in_features=48, out_features=16, bias=True))')
+    out = conv(x1, pos1, edge_index, vel)
+    assert out[0].size() == (4, 16)
+    assert out[1][0].size() == (4, 3)
+    assert out[1][1].size() == (4, 3)
+    assert torch.allclose(conv(x1, pos1, edge_index)[0], out[0], atol=1e-6)
+    assert conv(x1, pos1, edge_index)[1][1] is None
+    assert torch.allclose(conv(x1, pos1, adj.t(), vel)[0], out[0], atol=1e-6)
+    assert torch.allclose(conv(x1, pos1, adj.t())[0], out[0], atol=1e-6)
+
+    # not using fully-connected graph for positional updates
+    conv = EquivariantConv(local_nn, pos_nn, vel_nn, global_nn, use_fc=False)
     out = conv(x1, pos1, edge_index, vel)
     assert out[0].size() == (4, 16)
     assert out[1][0].size() == (4, 3)

--- a/test/nn/conv/test_equivariant_conv.py
+++ b/test/nn/conv/test_equivariant_conv.py
@@ -70,67 +70,50 @@ def test_equivariant_conv():
 
 
 def test_equivariant_conv_fc():
-
     pos = torch.tensor([[0.0],
                         [1.0],
                         [2.0],
                         [3.0]
                         ])
-
-
     edge_index = torch.tensor([[1, 0, 0, 2, 1, 3], [0, 1, 2, 0, 3, 1]])
     conv = EquivariantConv(local_nn=None, pos_nn=None,
                            vel_nn=None, global_nn=None)
     assert sum(m.numel() for m in conv.parameters()) == 0
-
     out = conv(x=None, pos=pos, vel=None,
                edge_index=edge_index, batch=None, edge_attr=None)
-
     x_feat = out[0]
     pos_feat = out[1][0]
 
     def euclid_dist_unidim(x1: float, x2: float) -> float:
-        return (x1-x2)**2
-
-
+        return (x1 - x2)**2
     # get fully-connected messages.
     # graph has N=4 nodes, so in-total (N*(N-1)/2) = 6 messages,
     # as no self-loops are considered
     m01 = euclid_dist_unidim(pos[0].item(), pos[1].item())
     m02 = euclid_dist_unidim(pos[0].item(), pos[2].item())
-
     m13 = euclid_dist_unidim(pos[1].item(), pos[3].item())
-
-
     # get hidden embedding `h`, based on local neighbourhood.
     h0 = m02 + m01
     h1 = m01 + m13
     h2 = m02
     h3 = m13
     assert torch.allclose(x_feat, torch.Tensor([[h0], [h1], [h2], [h3]]))
-
-
     # get hidden positions `x`, based on the fully-connected graph.
     x = pos
     x0 = x[0].item() + (1/3) * sum([x[0].item() - (x[1].item()),
                                     x[0].item() - (x[2].item()),
                                     x[0].item() - (x[3].item())
                                     ])
-
     x1 = x[1].item() + (1/3) * sum([x[1].item() - (x[0].item()),
                                     x[1].item() - (x[2].item()),
                                     x[1].item() - (x[3].item())
                                     ])
-
     x2 = x[2].item() + (1/3) * sum([x[2].item() - (x[0].item()),
                                     x[2].item() - (x[1].item()),
                                     x[2].item() - (x[3].item())
                                     ])
-
     x3 = x[3].item() + (1 / 3) * sum([x[3].item() - (x[0].item()),
                                       x[3].item() - (x[1].item()),
                                       x[3].item() - (x[2].item())
                                       ])
-
     assert torch.allclose(pos_feat, torch.Tensor([[x0], [x1], [x2], [x3]]))
-

--- a/test/nn/conv/test_equivariant_conv.py
+++ b/test/nn/conv/test_equivariant_conv.py
@@ -8,7 +8,8 @@ def test_equivariant_conv():
     x1 = torch.randn(4, 16)
     pos1 = torch.randn(4, 3)
     vel = torch.randn(4, 3)
-    edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    # edge_index = torch.tensor([[0, 1, 2, 3], [0, 0, 1, 1]])
+    edge_index = torch.tensor([[1, 0, 0, 2, 1, 3], [0, 1, 2, 0, 3, 1]])
     row, col = edge_index
     adj = SparseTensor(row=row, col=col, sparse_sizes=(4, 4))
 
@@ -56,3 +57,69 @@ def test_equivariant_conv():
                           atol=1e-6)
     assert torch.allclose(jit(x1, pos1, adj.t(), vel)[1][1], out[1][1],
                           atol=1e-6)
+
+
+def test_equivariant_conv_fc():
+
+    pos = torch.tensor([[0.0],
+                        [1.0],
+                        [2.0],
+                        [3.0]
+                        ])
+
+
+    edge_index = torch.tensor([[1, 0, 0, 2, 1, 3], [0, 1, 2, 0, 3, 1]])
+    conv = EquivariantConv(local_nn=None, pos_nn=None, vel_nn=None, global_nn=None)
+    assert sum(m.numel() for m in conv.parameters()) == 0
+
+    out = conv(x=None, pos=pos, edge_index=edge_index, vel=None, edge_attr=None)
+
+    x_feat = out[0]
+    pos_feat = out[1][0]
+
+    def euclid_dist_unidim(x1: float, x2: float) -> float:
+        return (x1-x2)**2
+
+
+    # get fully-connected messages.
+    # graph has N=4 nodes, so in-total (N*(N-1)/2) = 6 messages, as no self-loops are considered
+    m01 = m10 = euclid_dist_unidim(pos[0].item(), pos[1].item())
+    m02 = m20 = euclid_dist_unidim(pos[0].item(), pos[2].item())
+    m03 = m30 = euclid_dist_unidim(pos[0].item(), pos[3].item())
+
+    m12 = m21 = euclid_dist_unidim(pos[1].item(), pos[2].item())
+    m13 = m31 = euclid_dist_unidim(pos[1].item(), pos[3].item())
+
+    m23 = m32 = euclid_dist_unidim(pos[2].item(), pos[3].item())
+
+    # get hidden embedding `h`, based on local neighbourhood.
+    h0 = m02 + m01
+    h1 = m01 + m13
+    h2 = m02
+    h3 = m13
+    assert torch.allclose(x_feat, torch.Tensor([[h0], [h1], [h2], [h3]]))
+
+
+    # get hidden positions `x`, based on the fully-connected graph.
+    x = pos
+    x0 = x[0].item() + (1/3) * sum([x[0].item() - (x[1].item()),
+                                    x[0].item() - (x[2].item()),
+                                    x[0].item() - (x[3].item())
+                                    ])
+
+    x1 = x[1].item() + (1/3) * sum([x[1].item() - (x[0].item()),
+                                    x[1].item() - (x[2].item()),
+                                    x[1].item() - (x[3].item())
+                                    ])
+
+    x2 = x[2].item() + (1/3) * sum([x[2].item() - (x[0].item()),
+                                    x[2].item() - (x[1].item()),
+                                    x[2].item() - (x[3].item())
+                                    ])
+
+    x3 = x[3].item() + (1 / 3) * sum([x[3].item() - (x[0].item()),
+                                      x[3].item() - (x[1].item()),
+                                      x[3].item() - (x[2].item())
+                                      ])
+
+    assert torch.allclose(pos_feat, torch.Tensor([[x0], [x1], [x2], [x3]]))

--- a/torch_geometric/nn/conv/equivariant_conv.py
+++ b/torch_geometric/nn/conv/equivariant_conv.py
@@ -1,14 +1,64 @@
 from typing import Optional, Callable, Tuple
-from torch_geometric.typing import OptTensor, Adj
+from torch_geometric.typing import OptTensor, Adj, SparseTensor
 
 import torch
 from torch import Tensor
-from torch_sparse import SparseTensor, set_diag
 from torch_scatter import scatter
 from torch_geometric.nn.conv import MessagePassing
-from torch_geometric.utils import remove_self_loops, add_self_loops
 
-from ..inits import reset
+from torch_geometric.nn.inits import reset
+
+
+def get_fully_connected_get_edges(n_nodes: int, add_self_loops: bool = False) -> Tensor:
+    """
+    Creates the edge_index in COO format in a fully-connected graph with :obj:`n_nodes` nodes.
+    """
+    edge_index = torch.cartesian_prod(torch.arange(n_nodes), torch.arange(n_nodes)).T
+    if not add_self_loops:
+        edge_index = edge_index.t()[edge_index[0] != edge_index[1]].t()
+
+    return edge_index
+
+
+def get_fully_connected_edges_in_batch(batch_num_nodes: Tensor, ptr: Tensor,
+                                       edge_index: Tensor,
+                                       add_self_loops: bool = False,
+                                       edge_attr: OptTensor = None) -> Tuple[Tensor, OptTensor]:
+    """
+    Creates the edge_index in COO format in a fully-connected graph in a batch
+    """
+    fc_edge_index = [get_fully_connected_get_edges(int(n), add_self_loops) + int(p) for n, p in zip(batch_num_nodes, ptr)]
+    fc_edge_index = torch.cat(fc_edge_index, dim=-1)
+
+    # create dictionary with string as keys, e.g. [0, 1] meaning the connectivity between source node_id 0 to 1
+    # the value of the position along dim=1 of edge_index
+    source_target_to_edge_idx = {str([int(s), int(t)]): i for s, t, i in zip(edge_index[0],
+                                                                             edge_index[1],
+                                                                             range(edge_index.size(1)))}
+    # positions of fake edge_index
+    source_target_to_fc_edge_idx = {str([int(s), int(t)]): i for s, t, i in zip(fc_edge_index[0],
+                                                                                fc_edge_index[1],
+                                                                                range(fc_edge_index.size(1)))}
+
+    fake_edges = [s for s in source_target_to_fc_edge_idx.keys() if s not in source_target_to_edge_idx.keys()]
+    fake_edges_ids = [source_target_to_fc_edge_idx[k] for k in fake_edges]
+    # E_fc = fc_edge_index.shape[1]
+    # E = edge_index.shape[1]
+    # assert len(fake_edges) == E_fc - E
+    fake_edge_index = fc_edge_index.t()[fake_edges_ids].t()
+
+    # concatenate behind the fake-edges along the true edge_index
+    all_edge_index = torch.cat([edge_index, fake_edge_index], dim=-1).long().to(edge_index.device)
+
+    if edge_attr is not None:
+        # concatenate/zero-pad the fake edge_attr behind the true edge_attr
+        fake_edge_attr = torch.zeros(size=(fake_edge_index.size(1), edge_attr.size(-1)),
+                                     device=edge_index.device)
+        all_edge_attr = torch.cat([edge_attr, fake_edge_attr], dim=0).to(edge_attr.device)
+    else:
+        all_edge_attr = None
+
+    return all_edge_index, all_edge_attr
 
 
 class EquivariantConv(MessagePassing):
@@ -45,7 +95,7 @@ class EquivariantConv(MessagePassing):
             of shape :obj:`[-1, 2*in_channels + 1 +edge_dim]`
             to shape :obj:`[-1, hidden_channels]`, *e.g.*, defined by
             :class:`torch.nn.Sequential`. (default: :obj:`None`)
-        pos_nn (torch.nn.Module,optinal): A neural network
+        pos_nn (torch.nn.Module,optional): A neural network
             :math:`\rho_{\mathbf{\Theta}}` that
             maps message :obj:`m` of shape
             :obj:`[-1, hidden_channels]`,
@@ -63,11 +113,9 @@ class EquivariantConv(MessagePassing):
             :obj:`[-1, hidden_channels + in_channels]`
             to shape :obj:`[-1, out_channels]`, *e.g.*, defined by
             :class:`torch.nn.Sequential`. (default: :obj:`None`)
-        add_self_loops (bool, optional): If set to :obj:`False`, will not add
-            self-loops to the input graph. (default: :obj:`True`)
-        aggr (string, optional): The operator used to aggregate message
+        aggr (string, optional): The operator used to aggregate message for hidden node embeddings
             :obj:`m` (:obj:`"add"`, :obj:`"mean"`).
-            (default: :obj:`"mean"`)
+            (default: :obj:`"add"`)
         **kwargs (optional): Additional arguments of
             :class:`torch_geometric.nn.conv.MessagePassing`.
     """
@@ -75,14 +123,13 @@ class EquivariantConv(MessagePassing):
                  pos_nn: Optional[Callable] = None,
                  vel_nn: Optional[Callable] = None,
                  global_nn: Optional[Callable] = None,
-                 add_self_loops: bool = True, aggr="mean", **kwargs):
+                 aggr: str = "add", **kwargs):
         super(EquivariantConv, self).__init__(aggr=aggr, **kwargs)
 
         self.local_nn = local_nn
         self.pos_nn = pos_nn
         self.vel_nn = vel_nn
         self.global_nn = global_nn
-        self.add_self_loops = add_self_loops
 
         self.reset_parameters()
 
@@ -96,19 +143,33 @@ class EquivariantConv(MessagePassing):
     def forward(self, x: OptTensor,
                 pos: Tensor,
                 edge_index: Adj, vel: OptTensor = None,
-                edge_attr: OptTensor = None
+                edge_attr: OptTensor = None,
+                fc_edge_index: OptTensor = None,
+                batch_num_nodes: OptTensor = None,
+                ptr: OptTensor = None
                 ) -> Tuple[Tensor, Tuple[Tensor, OptTensor]]:
         """"""
-        if self.add_self_loops:
-            if isinstance(edge_index, Tensor):
-                edge_index, _ = remove_self_loops(edge_index)
-                edge_index, _ = add_self_loops(edge_index,
-                                               num_nodes=pos.size(0))
-            elif isinstance(edge_index, SparseTensor):
-                edge_index = set_diag(edge_index)
+
+        if isinstance(edge_index, SparseTensor):
+            row, col, _ = edge_index.coo()
+            edge_index = torch.stack([row, col], dim=0)
+
+        # if fc_edge_index and batch_num_nodes are not provided:
+        # create fully-connected edge-index if not passed
+        # note, then it assumes that the entire batch just consists of ONE graph
+        if batch_num_nodes is None:
+            batch_num_nodes = torch.tensor([pos.size(0)], device=pos.device, dtype=torch.long)
+        if ptr is None:
+            ptr = torch.tensor([0], device=pos.device, dtype=torch.long)
+        if fc_edge_index is None:
+            fc_edge_index, edge_attr = get_fully_connected_edges_in_batch(batch_num_nodes=batch_num_nodes,
+                                                                          ptr=ptr, edge_index=edge_index,
+                                                                          add_self_loops=False,
+                                                                          edge_attr=edge_attr)
+
 
         # propagate_type: (x: OptTensor, pos: Tensor, edge_attr: OptTensor) -> Tuple[Tensor,Tensor] # noqa
-        out_x, out_pos = self.propagate(edge_index, x=x, pos=pos,
+        out_x, out_pos = self.propagate(edge_index=fc_edge_index, orig_index=edge_index[1], x=x, pos=pos,
                                         edge_attr=edge_attr, size=None)
 
         out_x = out_x if x is None else torch.cat([x, out_x], dim=1)
@@ -140,9 +201,10 @@ class EquivariantConv(MessagePassing):
         return (msg, pos_msg)
 
     def aggregate(self, inputs: Tuple[Tensor, Tensor],
-                  index: Tensor) -> Tuple[Tensor, Tensor]:
-        return (scatter(inputs[0], index, 0, reduce=self.aggr),
-                scatter(inputs[1], index, 0, reduce="mean"))
+                  index: Tensor, orig_index: Tensor) -> Tuple[Tensor, Tensor]:
+        node_aggr_messages = scatter(inputs[0][:len(orig_index)], orig_index, 0, reduce=self.aggr)
+        node_aggr_positional = scatter(inputs[1], index, 0, reduce="mean")
+        return (node_aggr_messages, node_aggr_positional)
 
     def update(self, inputs: Tuple[Tensor, Tensor]) -> Tuple[Tensor, Tensor]:
         return inputs

--- a/torch_geometric/nn/conv/equivariant_conv.py
+++ b/torch_geometric/nn/conv/equivariant_conv.py
@@ -9,7 +9,7 @@ from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.inits import reset
 
 
-def get_fully_connected_get_edges(n_nodes: int, add_self_loops: bool = False) -> Tensor:
+def get_fully_connected_edges(n_nodes: int, add_self_loops: bool = False) -> Tensor:
     """
     Creates the edge_index in COO format in a fully-connected graph with :obj:`n_nodes` nodes.
     """
@@ -27,7 +27,7 @@ def get_fully_connected_edges_in_batch(batch_num_nodes: Tensor, ptr: Tensor,
     """
     Creates the edge_index in COO format in a fully-connected graph in a batch
     """
-    fc_edge_index = [get_fully_connected_get_edges(int(n), add_self_loops) + int(p) for n, p in zip(batch_num_nodes, ptr)]
+    fc_edge_index = [get_fully_connected_edges(int(n), add_self_loops) + int(p) for n, p in zip(batch_num_nodes, ptr)]
     fc_edge_index = torch.cat(fc_edge_index, dim=-1)
 
     # create dictionary with string as keys, e.g. [0, 1] meaning the connectivity between source node_id 0 to 1


### PR DESCRIPTION
Hi @wsad1 ,
as discussed in #2824 , I update the code for the equivariant conv. 
Changes been made:

1. for an (optional) batch, create the fully-connected graph edge_index in COO format. Crucial point is the offset parameter `ptr` which can optionally be passed in forward. As the `EquivariantConv` is a module in a GNN, I included the option to pass the `fc_edge_index` right away, as this can be calculated once, and passed forward for the consecutive `EquivariantConv` message-passing layers.
2. handle edge-attributes in the fully-connected graph. Essentially, I zero-pad the 0-vector for the "fake" edge-indices in the fully-connected graph, that are non-present but still needed for updating the positional features. For the `self.local_nn` then, users should make sure that the `self.local_nn` does not contain a bias vector for the first linear layer (or at least the biases at positional-dim, where the edge_attr are considered should be 0).
3. added tests to make sure the `EquivariantConv` updates the node embeddings `h` based on `edge_index` and the positional features `x` based on `fc_edge_index`

